### PR TITLE
Update Blog Post Rubric link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Students by the end of the course will be able to ...
 - **[SPD 1.2 Blog Post: UI/UX](https://docs.google.com/document/d/1rfXVN1ldCbYt_2u9drXXOszQFlvTEW1xZi8-5Kh7XJQ/edit#heading=h.pxjuoqz282qp)** -  link has the fully fledged assignment. Work on this assignment throughout the course instead of saving it for last minute. This blog post will serve as a valuable portfolio to demonstrate your skill to recruiters. 
   - Draft due December 5th, which will be our feedback class
   - Final due December 10th
-  - Grading: [Blog Post Rubric](https://drive.google.com/file/d/1Q7kd-JTwd8COOGNeSD43UoAivwF5_dWZ/view?usp=sharing) will be used to evaluate your work. Students must score an average of 2 or above to pass.
+  - Grading: [Blog Post Rubric](https://docs.google.com/document/d/1T1oqHFoRo0kl7mPUTFupmsoEkLYltKsVgtqyGKDaCgY/edit) will be used to evaluate your work. Students must score an average of 2 or above to pass.
 - Classroom activities mentioned below
 - **Term 2: Product - MVP Due November 28th, and Polished Due December 10th**
   - Version 1 due November 28th, shipped “skateboard” that scores a 3 on the [intensive rubric](https://docs.google.com/document/d/1pdtRdgVISE07fFc8oBi5hCnLkwBQDFG5_3f79aDV1WU/edit)


### PR DESCRIPTION
This doc https://docs.google.com/document/d/1rfXVN1ldCbYt_2u9drXXOszQFlvTEW1xZi8-5Kh7XJQ/edit# says that we will be graded on https://docs.google.com/document/d/1T1oqHFoRo0kl7mPUTFupmsoEkLYltKsVgtqyGKDaCgY/edit rubric, but that is not the rubric being linked from the course repo

Was that intentional? I assume not so I am submitting this PR to correct the link